### PR TITLE
Avoid using non-existent interface name

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,9 +210,8 @@
         </p>
         <p>
           We specify that if the user chooses to capture a [=browser=] [=display-surface=], the user
-          agent MUST instantiate the video track as either {{MediaStreamTrack}} or some sub-class of
-          it. For the purposes of the current document, designate the track's class as
-          <dfn>MediaStreamTrackOrSubclassThereof</dfn>.
+          agent MUST instantiate the video track as a {{MediaStreamTrack}}</p>
+        <p class="note">The Working Group is <a href="https://github.com/w3c/mediacapture-region/issues/3">discussing the class hierarchy for this new class</a>.
         </p>
         <p>
           For simplicity's sake, this document assumes that a subclass called
@@ -222,7 +221,7 @@
         <p>The track MUST be initially [=uncropped=].</p>
         <pre class="idl">
           [Exposed = Window]
-          interface BrowserCaptureMediaStreamTrack : MediaStreamTrackOrSubclassThereof {
+          interface BrowserCaptureMediaStreamTrack : MediaStreamTrack {
             Promise&lt;undefined&gt; cropTo(CropTarget? cropTarget);
             BrowserCaptureMediaStreamTrack clone();
           };


### PR DESCRIPTION
This creates non-usable IDL extracts (that harms e.g. Web Platform Tests)

related to #3


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/pull/15.html" title="Last updated on Jan 27, 2022, 3:05 PM UTC (2777054)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/15/abf0249...2777054.html" title="Last updated on Jan 27, 2022, 3:05 PM UTC (2777054)">Diff</a>