### PR TITLE
Remove MediaStreamTrackOrSubclassThereof

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
       </p>
     </section>
     <section id="sotd">
-      The Web Real-Time Communications Working Group is iterating on this proposal before proposing a First Public Working Draft.
+      The Web Real-Time Communications Working Group is iterating on this proposal before proposing
+      a First Public Working Draft.
     </section>
     <section id="conformance"></section>
     <section id="definitions">
@@ -206,23 +207,19 @@
         <p>
           Recall that, as per [[SCREEN-CAPTURE]], when {{MediaDevices/getDisplayMedia()}} is called,
           it returns a {{Promise}}&lt;{{MediaStream}}&gt;, and that this {{MediaStream}} contains
-          exactly one video track.
+          exactly one video track, whose type is {{MediaStreamTrack}}.
         </p>
         <p>
           We specify that if the user chooses to capture a [=browser=] [=display-surface=], the user
-          agent MUST instantiate the video track as either {{MediaStreamTrack}} or some sub-class of
-          it. For the purposes of the current document, designate the track's class as
-          <dfn>MediaStreamTrackOrSubclassThereof</dfn>.
-        </p>
-        <p>
-          For simplicity's sake, this document assumes that a subclass called
-          {{BrowserCaptureMediaStreamTrack}} is used by the user agent, but user agents MAY use
-          either {{MediaStreamTrack}} itself, or any other sub-class of {{MediaStreamTrack}}.
+          agent MUST instantiate the video track as either {{MediaStreamTrack}}, or as some
+          sub-class of {{MediaStreamTrack}}, and that {{BrowserCaptureMediaStreamTrack/cropTo}} MUST
+          be exposed on this track. For simplicity's sake, this document assumes that a subclass
+          called {{BrowserCaptureMediaStreamTrack}} is used by the user agent.
         </p>
         <p>The track MUST be initially [=uncropped=].</p>
         <pre class="idl">
           [Exposed = Window]
-          interface BrowserCaptureMediaStreamTrack : MediaStreamTrackOrSubclassThereof {
+          interface BrowserCaptureMediaStreamTrack : MediaStreamTrack {
             Promise&lt;undefined&gt; cropTo(CropTarget? cropTarget);
             BrowserCaptureMediaStreamTrack clone();
           };


### PR DESCRIPTION
Fixes #3 by removing MediaStreamTrackOrSubclassThereof and explaining that either MediaStreamTrack or a sub-class of MediaStreamTrack are to be instantiated, so long as `cropTo` is exposed on whatever is instantiated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-region/pull/16.html" title="Last updated on Jan 27, 2022, 6:32 PM UTC (147fca3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/16/abf0249...eladalon1983:147fca3.html" title="Last updated on Jan 27, 2022, 6:32 PM UTC (147fca3)">Diff</a>