### PR TITLE
Refer to getBoundingClientRect as a defintion of the actual crop area

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,21 @@
           };
         </pre>
         <dl data-link-for="CropTarget" data-dfn-for="CropTarget"></dl>
+        <p>
+          To <dfn data-export>create a CropTarget</dfn> with <var>element</var> as input, run the following steps:
+          <ol>
+            <li>
+              <p>Let <var>cropTarget</var> be a new object of type {{CropTarget}}.</p>
+            </li>
+            <li>
+              <p>Create <var>cropTarget</var>.<dfn data-dfn-for="CropTarget">[[\Element]]</dfn> initialized to <var>element</var>.</p>
+              <div class="note">
+                <p><var>cropTarget</var> is keeping a weak reference to the element it is representing.
+                  In other words, <var>cropTarget</var> will not prevent garbage collection of its element.</p>
+              </div>
+            </li>
+          </ol>
+        </p>
       </section>
       <section id="producecroptarget-method">
         <h3>MediaDevices.produceCropTarget</h3>
@@ -168,33 +183,27 @@
           </dt>
           <dd>
             <p>
-              The first call of {{MediaDevices/produceCropTarget}} on an {{HTMLElement}} of a
-              supported type, permanently associates that element with a {{CropTarget}}. Subsequent
-              calls return the same {{CropTarget}}. This {{CropTarget}} may be used as input to
+              Calling {{MediaDevices/produceCropTarget}} on an {{HTMLElement}} of a
+              supported type associates that element with a {{CropTarget}}.
+              This {{CropTarget}} may be used as input to
               {{BrowserCaptureMediaStreamTrack/cropTo}}. We define a
               <dfn>valid CropTarget</dfn> as one returned by a previous call to
               {{MediaDevices/produceCropTarget()}} in the current [=browsing context=].
             </p>
             <p>
-              When {{MediaDevices/produceCropTarget}} is first called on a given <var>element</var>,
-              the user agent MUST produce a new unique {{CropTarget}} and permanently associate it
-              with <var>element</var>. The user agent MUST return a {{Promise}} <var>P</var>. The
+              When {{MediaDevices/produceCropTarget}} is called on a given <var>element</var>,
+              the user agent [=create a CropTarget|creates a CropTarget=] with <var>element</var> as input.
+              The user agent MUST return a {{Promise}} <var>P</var>. The
               user agent MUST resolve <var>P</var> only after it has finished all the necessary
               internal propagation of state associated with the new {{CropTarget}}, at which point
               the user agent MUST be ready to receive the new {{CropTarget}} as a valid parameter to
               {{BrowserCaptureMediaStreamTrack/cropTo}}.
             </p>
             <p>
-              Subsequent calls to {{MediaDevices/produceCropTarget}} MUST return a new {{Promise}}
-              that behaves the same way <var>P</var> does. Specifically, the new {{Promise}} MUST
-              resolve after <var>P</var>, and MUST resolve to the same {{CropTarget}} as
-              <var>P</var>.
-            </p>
-            <p>
               When cloning an {{HTMLElement}} on which {{MediaDevices/produceCropTarget}} was
-              previously called, the clone MUST NOT be associated with any {{CropTarget}}. If
+              previously called, the clone is not associated with any {{CropTarget}}. If
               {{MediaDevices/produceCropTarget}} is later called on the clone, a new {{CropTarget}}
-              MUST be assigned to it.
+              will be assigned to it.
             </p>
           </dd>
         </dl>
@@ -234,8 +243,11 @@
           <dd>
             <p>
               Calls to this method instruct the user agent to start/stop cropping a [=self-capture
-              video track=] to the contours of the element referenced by
-              <var>cropTarget</var>. Whenever {{BrowserCaptureMediaStreamTrack/cropTo}} is invoked,
+              video track=] to the <a href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
+              bounding client rectangle</a> of <var>cropTarget</var>.[[\Element]].
+              Since the track is restricted to the visible viewport of the [=display-surface=],
+              the captured area will be the intersection of the visible viewport and the element bounding client rectangle.
+              Whenever {{BrowserCaptureMediaStreamTrack/cropTo}} is invoked,
               the user agent MUST execute the following algorithm:
             </p>
             <ol>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,8 @@
               <p>Let <var>cropTarget</var> be a new object of type {{CropTarget}}.</p>
             </li>
             <li>
-              <p>Create <var>cropTarget</var>.<dfn data-dfn-for="CropTarget">[[\Element]]</dfn> initialized to <var>element</var>.</p>
+              <p>Let <var>weakRef</var> be a weak reference to <var>element</var>.</p>
+              <p>Create <var>cropTarget</var>.<dfn data-dfn-for="CropTarget">[[\Element]]</dfn> initialized to <var>weakRef</var>.</p>
               <div class="note">
                 <p><var>cropTarget</var> is keeping a weak reference to the element it is representing.
                   In other words, <var>cropTarget</var> will not prevent garbage collection of its element.</p>


### PR DESCRIPTION
Make CropTarget have an internal slot to keep a reference to its element.
This fixes https://github.com/w3c/mediacapture-region/issues/20 and might be useful for serialisation steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-region/pull/32.html" title="Last updated on Mar 31, 2022, 4:19 PM UTC (1acb49b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/32/fda7d5f...youennf:1acb49b.html" title="Last updated on Mar 31, 2022, 4:19 PM UTC (1acb49b)">Diff</a>