### PR TITLE
Add a note stating the intent to get consistency between cropTo promise resolution and enqueueuing in the ReadableStream

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,12 @@
                   any additional frames delivered to the application will therefore be cropped (or
                   uncropped) according to either <var>POST-STATE</var> or a later state.
                 </p>
+                <div class="note">
+                  <p>The timing of the cropTo promise resolution and the timing of the actual cropping of video frames
+                  is observable to JavaScript through <a href="https://w3c.github.io/mediacapture-transform/">
+                  MediaStreamTrack transforms</a>. It is expected that the first newly cropped video frame will
+                  be enqueued on the MediaStreamTrack ReadableStream just after the cropTo promise is resolved.</p>
+                </div>
               </li>
             </ol>
           </dd>

--- a/index.html
+++ b/index.html
@@ -296,10 +296,12 @@
                   uncropped) according to either <var>POST-STATE</var> or a later state.
                 </p>
                 <div class="note">
-                  <p>The timing of the cropTo promise resolution and the timing of the actual cropping of video frames
-                  is observable to JavaScript through <a href="https://w3c.github.io/mediacapture-transform/">
-                  MediaStreamTrack transforms</a>. It is expected that the first newly cropped video frame will
-                  be enqueued on the MediaStreamTrack ReadableStream just after the cropTo promise is resolved.</p>
+                  <p>
+                    The timing of the cropTo promise resolution and the timing of the actual cropping of video frames
+                    is observable to JavaScript through <a href="https://w3c.github.io/mediacapture-transform/">
+                    MediaStreamTrack transforms</a>. It is expected that the first newly cropped video frame will
+                    be enqueued on the MediaStreamTrack ReadableStream just after the cropTo promise is resolved.
+                  </p>
                 </div>
               </li>
             </ol>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-region/issues/12


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-region/pull/33.html" title="Last updated on Mar 24, 2022, 4:13 PM UTC (a62294d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/33/d0bad7f...youennf:a62294d.html" title="Last updated on Mar 24, 2022, 4:13 PM UTC (a62294d)">Diff</a>