### PR TITLE
Fix w3cid and added document status

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
     <title>Region Capture</title>
     <script class="remove" src="region-capture.js" type="text/javascript"></script>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script src="respec-w3c.js" class="remove"></script>
   </head>
   <body>
     <section id="abstract">
@@ -15,8 +15,7 @@
       </p>
     </section>
     <section id="sotd">
-      The Web Real-Time Communications Working Group is iterating on this proposal before proposing
-      a First Public Working Draft.
+      This First Public Working Draft represents the direction the Web Real-Time Communications Working Group intends to explore to solve the use case of partial capture of browsing contexts. The Working Group is particularly interested in feedback on how well this direction matches the said use case from potential adopters of the API.
     </section>
     <section id="conformance"></section>
     <section id="definitions">

--- a/region-capture.js
+++ b/region-capture.js
@@ -1,6 +1,6 @@
 var respecConfig = {
   group: "webrtc",
-  specStatus: "FPWD",
+  specStatus: "ED",
   github: {
     repoURL: "https://github.com/w3c/mediacapture-region/",
     branch: "main",

--- a/region-capture.js
+++ b/region-capture.js
@@ -1,6 +1,6 @@
 var respecConfig = {
   group: "webrtc",
-  specStatus: "ED",
+  specStatus: "FPWD",
   github: {
     repoURL: "https://github.com/w3c/mediacapture-region/",
     branch: "main",
@@ -10,7 +10,7 @@ var respecConfig = {
       name: "Elad Alon",
       email: "eladalon@google.com",
       company: "Google",
-      w3cId:  118124
+      w3cid:  118124
     },
   ],
   xref: ["html", "infra", "permissions", "permissions-policy", "dom", "mediacapture-streams", "webidl", "screen-capture"],


### PR DESCRIPTION
Also fixes a typo - s/w3cId/w3cid


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 4, 2022, 10:12 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Feladalon1983%2Fmediacapture-region%2F81c0c65b88205a976423d89c06f0f5413a87c20a%2Findex.html%3FisPreview%3Dtrue)

```
waiting for function failed: timeout 30000ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mediacapture-region%2338.)._
</details>
