### PR TITLE
Fix inaccurate definition around browsing contexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,11 @@
         <dfn>display-surface</dfn> and <dfn>browser</dfn> [=display-surface=].
       </p>
       <p>
-        This specification defines <dfn>self-capture</dfn> as the capture of a
-        [=browser=] [=display-surface=] that is the rendered form of the
-        [=top-level browsing context=] of the [=associated Document=] of the
-        {{MediaDevices}} object from which the application initiated the
-        capture session. A <dfn>self-capture video track</dfn> is a
-        {{MediaStreamTrack}} sourced by <a>self-capture</a>.
+        This specification defines <dfn>self-capture</dfn> as the capture of a [=browser=]
+        [=display-surface=] that is the rendered form of the [=top-level browsing context=] of the
+        [=associated Document=] of the {{MediaDevices}} object from which the application initiated
+        the capture session. A <dfn>self-capture video track</dfn> is a {{MediaStreamTrack}} sourced
+        by <a>self-capture</a>.
       </p>
     </section>
     <section class="informative" id="use-cases">
@@ -52,14 +51,14 @@
       <section id="practical-use-case">
         <h3>Practical Use-Case</h3>
         <p>
-          Consider a combo-application consisting of two major parts in different iframes - a
-          video-conferencing application and a productivity-suite application. Assume the
-          video-conferencing uses existing/upcoming APIs such as {{MediaDevices/getDisplayMedia()}}
-          and/or <code>getViewportMedia</code> and captures the entire tab. Now it needs to crop
-          away everything other than a particular section of the productivity-suite. It needs to
-          crop away its own video-conferencing content, any speaker notes and other private and/or
-          irrelevant content in the productivity-suite, before transmitting the resulting cropped
-          video remotely.
+          Consider a combo-application consisting of two major parts hosted in different iframes
+          within the same tab - a video-conferencing application and a productivity-suite
+          application. Assume the video-conferencing uses existing/upcoming APIs such as
+          {{MediaDevices/getDisplayMedia()}} and/or <code>getViewportMedia</code> and captures the
+          entire tab. Now it needs to crop away everything other than a particular section of the
+          productivity-suite. It needs to crop away its own video-conferencing content, any speaker
+          notes and other private and/or irrelevant content in the productivity-suite, before
+          transmitting the resulting cropped video remotely.
         </p>
         <p>
           Moreover, consider that it is likely that the two collaborating applications are


### PR DESCRIPTION
Fixes #40.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-region/pull/41.html" title="Last updated on Apr 8, 2022, 6:33 PM UTC (a2d02a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/41/efc006b...eladalon1983:a2d02a3.html" title="Last updated on Apr 8, 2022, 6:33 PM UTC (a2d02a3)">Diff</a>