### PR TITLE
Revert "Remove obsolete note"

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,12 @@
             // Intentionally empty; just an opaque identifier.
           };
         </pre>
+        <div class="note">
+          <p>
+            There is no consensus yet on the name for {{CropTarget}}. This is under discussion in
+            <a href="https://github.com/w3c/mediacapture-region/issues/18">issue #18</a>.
+          </p>
+        </div>
         <dl data-link-for="CropTarget" data-dfn-for="CropTarget"></dl>
         <p>
           To <dfn data-export>create a CropTarget</dfn> with <var>element</var> as input, run the


### PR DESCRIPTION
This reverts commit 0143336f7050d777fee8aed3171c61bb4decefe1.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-region/pull/52.html" title="Last updated on May 31, 2022, 9:04 AM UTC (808e4c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/52/0143336...eladalon1983:808e4c1.html" title="Last updated on May 31, 2022, 9:04 AM UTC (808e4c1)">Diff</a>