### PR TITLE
Remove obsolete note (name of CropTarget)

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,12 +154,6 @@
             // Intentionally empty; just an opaque identifier.
           };
         </pre>
-        <div class="note">
-          <p>
-            There is no consensus yet on the name for {{CropTarget}}. This is under discussion in
-            <a href="https://github.com/w3c/mediacapture-region/issues/18">issue #18</a>.
-          </p>
-        </div>
         <dl data-link-for="CropTarget" data-dfn-for="CropTarget"></dl>
         <p>
           To <dfn data-export>create a CropTarget</dfn> with <var>element</var> as input, run the


### PR DESCRIPTION
Fixes #18.
I believe the discussion over names and bespoke IDs vs. single-purpose IDs is now complete.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-region/pull/53.html" title="Last updated on May 31, 2022, 9:07 AM UTC (a8317e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/53/1019828...eladalon1983:a8317e8.html" title="Last updated on May 31, 2022, 9:07 AM UTC (a8317e8)">Diff</a>