### PR TITLE
Don't expose CropTarget.fromElement to worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         <pre class="idl">
           [Exposed=(Window,Worker), Serializable]
           interface CropTarget {
-            [SecureContext] static Promise&lt;CropTarget&gt; fromElement(Element element);
+            [Exposed=Window, SecureContext] static Promise&lt;CropTarget&gt; fromElement(Element element);
           };
         </pre>
         <div class="note">


### PR DESCRIPTION
FIX https://github.com/w3c/mediacapture-region/issues/64


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-region/pull/68.html" title="Last updated on Jun 14, 2022, 7:20 AM UTC (cf257f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/68/b3cd0a6...beaufortfrancois:cf257f9.html" title="Last updated on Jun 14, 2022, 7:20 AM UTC (cf257f9)">Diff</a>