### PR TITLE
Remove outdated note (consensus on name "CropTarget")

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,12 +156,6 @@
         </pre>
         <div class="note">
           <p>
-            There is no consensus yet on the name for {{CropTarget}}. This is under discussion in
-            <a href="https://github.com/w3c/mediacapture-region/issues/18">issue #18</a>.
-          </p>
-        </div>
-        <div class="note">
-          <p>
             There is no consensus yet on whether {{CropTarget/fromElement}} should be exposed beyond
             secure contexts.
           </p>


### PR DESCRIPTION
Fixes #18.

Remove outdated note claiming lack of consensus over the name "CropTarget".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/pull/73.html" title="Last updated on Oct 14, 2022, 8:52 AM UTC (697b8ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-region/73/6c41d38...697b8ce.html" title="Last updated on Oct 14, 2022, 8:52 AM UTC (697b8ce)">Diff</a>